### PR TITLE
Added `netbox_celery_task` to replace `shared_task`

### DIFF
--- a/docker/configuration/configuration.example.py
+++ b/docker/configuration/configuration.example.py
@@ -222,6 +222,7 @@ PAGINATE_COUNT = int(environ.get("PAGINATE_COUNT", 50))
 # configuration.py
 PLUGINS = [
     "netbox_celery",
+    "example_plugin",
 ]
 
 # Plugins configuration settings. These settings are used by various plugins that the user may have installed.

--- a/docs/example-plugin/README.md
+++ b/docs/example-plugin/README.md
@@ -1,0 +1,1 @@
+# Example Plugin

--- a/docs/example-plugin/example_plugin/__init__.py
+++ b/docs/example-plugin/example_plugin/__init__.py
@@ -1,0 +1,20 @@
+"""Netbox Celery Plugin."""
+from extras.plugins import PluginConfig
+
+
+__version__ = "0.0.1"
+
+
+class ExamplePlugin(PluginConfig):
+    """Example Plugin."""
+
+    name = "example_plugin"
+    verbose_name = "Example Plugin"
+    version = __version__
+    author = "OpticoreIT"
+    author_email = "info@opticoreit.com"
+    description = "Celery job management for Netbox."
+    base_url = "celery"
+
+
+config = ExamplePlugin  # pylint: disable=invalid-name

--- a/docs/example-plugin/example_plugin/tasks.py
+++ b/docs/example-plugin/example_plugin/tasks.py
@@ -1,0 +1,8 @@
+"""Example Tasks File."""
+from netbox_celery.tasks import netbox_celery_task
+
+
+@netbox_celery_task(name="example_plugin:hello_world")
+def hello_world(self, task_id):
+    """Example hello world task."""
+    self.log("Hello World!")

--- a/docs/example-plugin/pyproject.toml
+++ b/docs/example-plugin/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "example-plugin"
+version = "0.1.0"
+description = ""
+authors = ["OpticoreIT <opensource@opticoreit.com>"]
+readme = "README.md"
+packages = [{include = "example_plugin"}]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/docs/models.md
+++ b/docs/models.md
@@ -23,9 +23,9 @@ Example:
 from netbox_celery.models import CeleryResult
 
 job = CeleryResult.enqueue_job(
-    "example_plugin:example_job",       # Name/Path of celery function
+    "example_plugin:hello_world",       # Name/Path of celery function
     user=None,                          # User who initiated the job
-    celery_kwargs={"countdown": 10},    # kwargs that are passed into `apply_async`
+    celery_kwargs={"countdown": 2},    # kwargs that are passed into `apply_async`
     args=[],                            # args that are passed into celery task function
     kwargs=[],                          # kwargs that are passed into celery task function
 )

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,8 +17,6 @@ The example below shows a very simple Celery task. Using the `shared_task` decor
 Required key work arguments:
 
 - `name` (str): Defines the name of the task. The plugin name should be used to stop any overlapping tasks.
-- `base` (class): Set the base class to bind with.
-- `bind` (bool): Binds the function with the base class.
 
 When the task is bound to the base, it inherits functions for logging and reporting task status. It also overwrites the `run()` function in the base class with the code from your function.
 
@@ -26,11 +24,10 @@ Whenever `CeleryBaseTask` is used, the first argument in the celery function nee
 
 ``` python
 # Example script
-from celery import shared_task
-from netbox_celery.tasks import CeleryBaseTask
+from netbox_celery.tasks import netbox_celery_task
 
 
-@shared_task(name="netbox_example_plugin:hello_world", base=CeleryBaseTask, bind=True)
+@netbox_celery_task(name="example_plugin:hello_world")
 def hello_world(self, task_id):
     self.log("Hello World!")
 ```

--- a/netbox_celery/tasks.py
+++ b/netbox_celery/tasks.py
@@ -3,6 +3,7 @@ import logging
 
 from datetime import datetime
 from celery.app.task import Task
+from celery import shared_task
 
 from netbox_celery.choices import CeleryResultStatusChoices
 from netbox_celery.models import CeleryResult
@@ -59,3 +60,12 @@ class CeleryBaseTask(Task):
     def log(self, level_choice=logging.INFO, message=""):
         """Log message."""
         self.task_obj.log(level_choice, message)
+
+
+def netbox_celery_task(*args, base=CeleryBaseTask, bind=True, **kwargs):
+    """Netbox Celery Task."""
+
+    def _netbox_celery_task(*args, **kwargs):
+        return shared_task(*args, **kwargs)
+
+    return _netbox_celery_task(*args, base=base, bind=bind, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ mkdocs-include-markdown-plugin = "3.8"
 pymdown-extensions = "^9.10"
 mkdocs-material = "^9.1.4"
 mkdocstrings = "^0.20.0"
+example-plugin = { path = "docs/example-plugin", develop = true }
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Custom celery decorator to remove some keyword arguments from `celery.shared_task`.
By default, any tasks being processed through `netbox_celery` need to inherit from `netbox_celery.tasks.CeleryBaseTask` and also have the kwargs `bind=True`.

`netbox_celery_task` sets this by default. The kwargs can still be overwritten.

An example plugin has been added to the repo for documentation and develop purposes.