### PR TITLE
max_length increased

### DIFF
--- a/netbox_celery/models.py
+++ b/netbox_celery/models.py
@@ -145,7 +145,7 @@ class CeleryLogEntry(models.Model):
 
     job_result = models.ForeignKey(CeleryResult, on_delete=models.CASCADE, related_name="logs")
     log_level = models.CharField(
-        max_length=32,
+        max_length=256,
         choices=LogLevelIntegerChoices,
         default=LogLevelIntegerChoices.LOG_DEFAULT,
         db_index=True,


### PR DESCRIPTION
Error caused by not specifying a platform. Error stack trace below. 

[2023-08-18 18:32:29,375: ERROR/MainProcess] Task handler raised error: DataError('value too long for type character varying(32)\n')
billiard.einfo.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/home/james/.cache/pypoetry/virtualenvs/opticore-netbox-saPIyhfk-py3.10/lib/python3.10/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/james/projects/opticore-netbox/plugins/netbox-celery/netbox_celery/tasks.py", line 30, in __call__
    return super().__call__(task_id, *args, **kwargs)
  File "/home/james/.cache/pypoetry/virtualenvs/opticore-netbox-saPIyhfk-py3.10/lib/python3.10/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/james/projects/opticore-netbox/plugins/netbox_config_backup/netbox_config_backup/tasks.py", line 92, in backup_device
    with InitNornir(
  File "/home/james/.cache/pypoetry/virtualenvs/opticore-netbox-saPIyhfk-py3.10/lib/python3.10/site-packages/nornir/init_nornir.py", line 72, in InitNornir
    inventory=load_inventory(config),
  File "/home/james/.cache/pypoetry/virtualenvs/opticore-netbox-saPIyhfk-py3.10/lib/python3.10/site-packages/nornir/init_nornir.py", line 20, in load_inventory
    inv = inventory_plugin(**config.inventory.options).load()
  File "/home/james/projects/opticore-netbox/plugins/netbox_nornir/netbox_nornir/plugins/inventory/netbox_orm.py", line 149, in load
    host = self.create_host(device, cred, {})
  File "/home/james/projects/opticore-netbox/plugins/netbox_nornir/netbox_nornir/plugins/inventory/netbox_orm.py", line 188, in create_host
    raise NornirNetboxException(f"Platform missing from device {device.name}, preemptively failed.")
netbox_nornir.exceptions.NornirNetboxException: Platform missing from device 12 Core Fibre to PI, preemptively failed.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/james/.cache/pypoetry/virtualenvs/opticore-netbox-saPIyhfk-py3.10/lib/python3.10/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(32)